### PR TITLE
Auto select first crate as active

### DIFF
--- a/KP-Cratefiller/KPCF/fnc/fn_getNearStorages.sqf
+++ b/KP-Cratefiller/KPCF/fnc/fn_getNearStorages.sqf
@@ -2,6 +2,8 @@
     Killah Potatoes Cratefiller v1.1.0
 
     Author: Dubjunk - https://github.com/KillahPotatoes
+    Edited by Mildly_Interested - https://github.com/MildlyInterestedEdited by Mildly_Interested - https://github.com/MildlyInterested
+
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -49,3 +51,11 @@ private ["_type", "_config", "_number", "_index", "_picture"];
         _ctrlStorage lbSetPicture [_index, _picture];
     };
 } forEach KPCF_nearStorage;
+
+// Set first found crate as active storage
+if (count KPCF_nearStorage > 0) then {
+    _ctrlStorage lbSetCurSel 0;
+    KPCF_activeStorage = KPCF_nearStorage select 0;
+} else {
+    KPCF_activeStorage = objNull;
+};


### PR DESCRIPTION
Addresses issue described here https://github.com/16AA-Milsim/MissionFramework/issues/28

The function used to get all close crates and populate the list, leading to the crate name and picture showing in the list but not yet being set to "active".

Led to some user confusion as to why the crate shows as selected but still produces the error "Incomplete Selection"