### PR TITLE
Whitelist access to cratefiller

### DIFF
--- a/KP-Cratefiller/KPCF/fnc/fn_init.sqf
+++ b/KP-Cratefiller/KPCF/fnc/fn_init.sqf
@@ -2,7 +2,8 @@
     Killah Potatoes Cratefiller v1.1.0
 
     Author: Dubjunk - https://github.com/KillahPotatoes
-
+    Edited by Mildly_Interested - https://github.com/MildlyInterested
+    
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -11,9 +12,21 @@
     Dependencies:
         * KPGUI
 */
+// Runs on every client to check if whitelisting is enabled/init whitelist lists
+KPCF_whitelisted = false;
+[] call compileFinal preprocessFileLineNumbers "KPCF_whitelist.sqf";
 
-// Only run, when we've a real player
-if (hasInterface) then {
+// Check if player is in any of the three whitelists
+if (KPCF_enable_whitelist &&  (
+        (getPlayerUID player in KP_cratefiller_whitelist_steam_id)
+    ||  (name player in KP_cratefiller_whitelist_player_name)
+    ||  (groupId (group player) in KP_cratefiller_whitelist_group_name)
+)) then {
+    KPCF_whitelisted = true;
+};
+
+// Only run, when we've got a real player & and has been whitelisted OR Whitelist is disabled
+if (hasInterface && (KPCF_whitelisted || !KPCF_enable_whitelist)) then {
 
     // Read the config file
     [] call compile preprocessFileLineNumbers "KPCF_config.sqf";

--- a/KP-Cratefiller/KPCF_whitelist.sqf
+++ b/KP-Cratefiller/KPCF_whitelist.sqf
@@ -1,0 +1,29 @@
+/*
+    Killah Potatoes Cratefiller v1.1.0
+
+    Author: Mildly Interested - https://github.com/MildlyInterested
+
+    License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
+
+    Description:
+    This will define the array of whitelisted Steam64IDs that are able to use Cratefiller.
+*/
+KPCF_enable_whitelist = false; //set to "true" if you want to limit Cratefiller only to certain users (users to be defined further down)
+
+//Whitelist based on Steam64ID, can be obtained here: https://steamid.io/
+KP_cratefiller_whitelist_steam_id = [
+    "STEAM64ID1",
+    "STEAM64ID2"
+];
+
+//Whitelist based on player name
+KP_cratefiller_whitelist_player_name = [
+    "Player1",
+    "Player2"
+];
+
+//Whitelist based on player group/squad name (the one you see in the editor, NOT the one you see in role selection)
+KP_cratefiller_whitelist_group_name = [
+    "Group1",
+    "Group2"
+];

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can spawn and delete defined crates, fill these crates and also other object
 * Easy management of large amounts of supplies
 * Overview of the present object inventory
 * Export and import function for inventories
+* Whitelist for players to access cratefiller
 
 ## Languages
 
@@ -44,7 +45,7 @@ Supported:
 
 Download the latest releases from the [Releases Tab](https://github.com/KillahPotatoes/dubjunks-scripts/releases) and extract the archive.
 
-Move the folder `KPGUI` and `KPCF` plus the files `description.ext` `KPCF_config.sqf` and `stringtable.xml` to the root of your mission folder, e.g.: exampleMission.Altis
+Move the folder `KPGUI` and `KPCF` plus the files `description.ext` `KPCF_config.sqf` `KPCF_whitelist.sqf` and `stringtable.xml` to the root of your mission folder, e.g.: exampleMission.Altis
 
 If you already have a `description.ext` you need to do the following instructions:
 


### PR DESCRIPTION
- added config file to define access list, default whitelist disabled
- can be whitelisted based on steamID, playername or playergroup
- whitelist config in separate file