### PR TITLE
Adjustable ACE carry/drag/cargo size

### DIFF
--- a/KP-Cratefiller/KPCF/fnc/fn_spawnCrate.sqf
+++ b/KP-Cratefiller/KPCF/fnc/fn_spawnCrate.sqf
@@ -2,6 +2,8 @@
     Killah Potatoes Cratefiller v1.1.0
 
     Author: Dubjunk - https://github.com/KillahPotatoes
+    Edited by Mildly_Interested - https://github.com/MildlyInterested
+    
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
@@ -44,6 +46,21 @@ if ((!(((getPos KPCF_activeSpawn) nearEntities 5) isEqualTo [])) && _checkSpawn)
 
 // Spawn crate
 private _crate = createVehicle [_crateType, ((getPos KPCF_activeSpawn) findEmptyPosition [0, 10, _crateType]), [], 0, "NONE"];
+
+// If enabled set ACE Cargo size of spawned crates to one
+if (KPCF_ace && KPCF_ace_cargo_one && (_crate isKindOf "ThingX")) then {
+    [_crate, 1] call ace_cargo_fnc_setSize;
+};
+
+// If enabled ignore weight limit for ACE DRAG for all crates created by cratefiller
+if (KPCF_ace && KPCF_ace_drag_all && (_crate isKindOf "ThingX")) then {
+    [_crate, true, nil, nil, true] remoteExec ["ace_dragging_fnc_setDraggable"];
+};
+
+// If enabled ignore weight limit for ACE CARRY for all crates created by cratefiller
+if (KPCF_ace && KPCF_ace_carry_all && (_crate isKindOf "ThingX")) then {
+    [_crate, true, nil, nil, true] remoteExec ["ace_dragging_fnc_setCarryable"];
+};
 
 // Clear the storage
 clearWeaponCargoGlobal _crate;

--- a/KP-Cratefiller/KPCF_config.sqf
+++ b/KP-Cratefiller/KPCF_config.sqf
@@ -11,9 +11,9 @@
 */
 
 //Configure ACE specific settings, these settings won't affect any other crates or objects in your mission, only objects spawned by KP Cratefiller
-KPCF_ace_drag_all = true;      // If you want to be able to ACE DRAG every crate (created by Cratefiller) regardless of weight set to "true"
-KPCF_ace_carry_all = true;     // If you want to be able to ACE CARRY every crate (created by Cratefiller) regardless of weight set to "true"
-KPCF_ace_cargo_one = true;     // Sets required cargo space to 1 for every crate (created by Catefiller) if set to "true"
+KPCF_ace_drag_all = false;      // If you want to be able to ACE DRAG every crate (created by Cratefiller) regardless of weight set to "true"
+KPCF_ace_carry_all = false;     // If you want to be able to ACE CARRY every crate (created by Cratefiller) regardless of weight set to "true"
+KPCF_ace_cargo_one = false;     // Sets required cargo space to 1 for every crate (created by Catefiller) if set to "true"
 
 // The Base object is for the player interaction, so at these object you can open the dialog
 KPCF_cratefillerBase = [

--- a/KP-Cratefiller/KPCF_config.sqf
+++ b/KP-Cratefiller/KPCF_config.sqf
@@ -2,11 +2,18 @@
     Killah Potatoes Cratefiller v1.1.0
 
     Author: Dubjunk - https://github.com/KillahPotatoes
+    Edited by Mildly_Interested - https://github.com/MildlyInterested
+    
     License: GNU General Public License v3.0 - https://www.gnu.org/licenses/gpl-3.0.html
 
     Description:
     Configuration file for various variables of the KP cratefiller.
 */
+
+//Configure ACE specific settings, these settings won't affect any other crates or objects in your mission, only objects spawned by KP Cratefiller
+KPCF_ace_drag_all = true;      // If you want to be able to ACE DRAG every crate (created by Cratefiller) regardless of weight set to "true"
+KPCF_ace_carry_all = true;     // If you want to be able to ACE CARRY every crate (created by Cratefiller) regardless of weight set to "true"
+KPCF_ace_cargo_one = true;     // Sets required cargo space to 1 for every crate (created by Catefiller) if set to "true"
 
 // The Base object is for the player interaction, so at these object you can open the dialog
 KPCF_cratefillerBase = [

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You can spawn and delete defined crates, fill these crates and also other object
 * Easy management of large amounts of supplies
 * Overview of the present object inventory
 * Export and import function for inventories
+* Configurable ACE3 Carry, Drag and Cargo Size settings
 
 ## Languages
 


### PR DESCRIPTION
Setting to adjust if:
Crates spawned in by cratefiller can be dragged regardless of weight
Crates spawned in by cratefiller can be carried regardless of weight
Cargo size for crates spawned in by cratefiller set to 1

Checks if spawned crate is of Type ThingX to avoid edge cases where cars and such are spawned in via cratefiller to avoid them being made draggable etc.